### PR TITLE
add option to allow duplicate ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ var config = {
       messagesPattern: I18N_DIR + 'messages/**/*.json',
       aggregateOutputDir: I18N_DIR + 'aggregate/',
       aggregateFilename: 'en-US'
+      allowDuplicates: false
     })
   ]
 }
@@ -51,3 +52,4 @@ module.exports = config;
 
 - **`aggregateFilename`**: The name of the file to be output that will get `.json` appended to it. Defaults to: `en-US`.
 
+- **`allowDuplicates`**: Allows use of duplicate message ids so long as the defaultMessage matches.  Defaults to: `false`.

--- a/src/index.js
+++ b/src/index.js
@@ -14,12 +14,15 @@ ReactIntlAggregatePlugin.prototype.apply = function (compiler) {
                             '../../i18n/aggregate/';
   let aggregateFilename  = this.plugin_options.aggregateFilename ||
                             'en-US';
+  let allowDuplicates    = this.plugin_options.allowDuplicates ||
+                            false;
 
   compiler.plugin('emit', function (compilation, callback) {
     const MESSAGES_PATTERN = path.resolve(__dirname, messagesPattern);
     const AGGREGATE_DIR    = path.resolve(__dirname, aggregateOutputDir);
     const AGGREGATE_FILE   = path.resolve(AGGREGATE_DIR, aggregateFilename +
                               '.json');
+    const ALLOW_DUPLICATES = allowDuplicates;
 
     console.log('Messages pattern: ' + MESSAGES_PATTERN);
     console.log('Aggregate dir: ' + AGGREGATE_DIR)
@@ -28,8 +31,17 @@ ReactIntlAggregatePlugin.prototype.apply = function (compiler) {
       .map((file) => JSON.parse(file))
       .reduce((collection, descriptors) => {
         descriptors.forEach(({id, defaultMessage, description}) => {
-          if (collection.hasOwnProperty(id)) {
+          if (
+            collection.hasOwnProperty(id) &&
+            !ALLOW_DUPLICATES
+          ) {
             throw new Error(`Duplicate message id: ${id}`);
+          }
+          else if (
+            collection.hasOwnProperty(id) &&
+            collection[id].defaultMessage &&
+          ) {
+            throw new Error(`Message with id: ${id} already exists, and defaultMessage does not match`);
           }
           collection[id] = {};
           collection[id]["defaultMessage"] = defaultMessage;


### PR DESCRIPTION
We use duplicate ids for common messaging across multiple components.  This adds an option to allow duplicate ids so long as the defaultMessages are the same.